### PR TITLE
increase frequency of backup age check

### DIFF
--- a/backup-tools/backup-image/Makefile
+++ b/backup-tools/backup-image/Makefile
@@ -1,7 +1,7 @@
 SHELL       := /bin/sh
 REGISTRY    := $(if $(REGISTRY),$(REGISTRY)/,)
 IMAGE       ?= sapcc/backup-tools
-VERSION     ?= v0.6.2
+VERSION     ?= v0.6.3
 DOCKERFILE  ?= Dockerfile.backup-image
 
 ### Proxy Foo

--- a/backup-tools/backup-image/go-src/backup-run.go
+++ b/backup-tools/backup-image/go-src/backup-run.go
@@ -63,7 +63,7 @@ func runServer(c *cli.Context) {
 				bp.SetSuccess(&timestamp)
 			}
 			bp.Finish()
-			time.Sleep(300 * time.Second)
+			time.Sleep(60 * time.Second)
 		}
 	}()
 


### PR DESCRIPTION
For my Postgres upgrade procedure, I'm triggering a backup manually right before tearing down the old datadir. But the only way to trigger a backup run manually is to reset the last_backup_timestamp. Right now, it will take up to 5 minutes until the backup container notices that and makes a new backup. This change reduces the wait time to max. 60 seconds.

This does not lead to more backups being produced. It's just about how often the last_backup_timestamp is downloaded from Swift for checking if a backup needs to be made.