### PR TITLE
allow to override OS_SERVICE_TYPE for Swift

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -39,6 +39,7 @@ func NewConfiguration(ctx context.Context) (*Configuration, error) {
 	if err != nil {
 		return nil, err
 	}
+	eo.Type = osext.GetenvOrDefault("OS_SERVICE_TYPE", "object-store")
 	client, err := openstack.NewObjectStorageV1(provider, eo)
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to Swift: %w", err)


### PR DESCRIPTION
For Ceph, we need to set OS_SERVICE_TYPE=object-store-ceph.